### PR TITLE
Delete hard definition of <Bundle-SymbolicName> with previously empty…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,6 @@
             <!-- no 'uses' osgi directive -->
             <_nouses>true</_nouses>
             <_snapshot>${osgi-version-qualifier}</_snapshot>
-            <Bundle-SymbolicName>${bundle-symbolicname}</Bundle-SymbolicName>
           </instructions>
         </configuration>
         <executions>


### PR DESCRIPTION
… variable to allow automatic naming

Found that issue of an empty Bundle-SymbolicName using p2-maven-plugin, where bundles without symbolic name are just ignored. Since the automatic calculation of a Bundle-SymbolicName is already provided by the maven-bundle-plugin, it is not necessary to set a custom name. Especially not with an empty variable...  ;-)