### PR TITLE
#147: Try to fix proxy not found if autoDetect is enabled but detectAutoProxyConfigUrl returns empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 This file contains the change log.
 
+## 1.1.6
+* Fixed issue #147: Unexpected proxy auto-detection result on Windows.
+* Update dependencies
+
 ## 1.1.5
 * Fixed issue #109: PListParser#base64decode does not expect data to be multiline. Thanks to vsalavatov!
 * Update dependencies

--- a/src/main/java/com/github/markusbernhardt/proxy/search/browser/ie/IEProxySearchStrategy.java
+++ b/src/main/java/com/github/markusbernhardt/proxy/search/browser/ie/IEProxySearchStrategy.java
@@ -107,8 +107,9 @@ public class IEProxySearchStrategy extends CommonWindowsSearchStrategy {
 			        WINHTTP_AUTO_DETECT_TYPE_DHCP | WINHTTP_AUTO_DETECT_TYPE_DNS_A);
                         pacUrl = WinHttpHelpers.detectAutoProxyConfigUrl(dwAutoDetectFlags);
 		}
-		if (pacUrl == null) {
+		if (pacUrl == null || pacUrl.trim().length() == 0) {
 			pacUrl = ieProxyConfig.getAutoConfigUrl();
+            Logger.log(getClass(), LogLevel.TRACE, "Autodetecting script URL did not return valid pacUrl. Use autoConfigUrl from IE proxy config: " + pacUrl);
 		}
 		if (pacUrl != null && pacUrl.trim().length() > 0) {
 			Logger.log(getClass(), LogLevel.TRACE, "IE uses script: " + pacUrl);
@@ -120,6 +121,9 @@ public class IEProxySearchStrategy extends CommonWindowsSearchStrategy {
 				pacUrl = "file:///" + pacUrl.substring(7);
 			}
 			return ProxyUtil.buildPacSelectorForUrl(pacUrl);
+		}
+		else {
+            Logger.log(getClass(), LogLevel.TRACE, "The pacUrl for IE is not available: " + pacUrl);
 		}
 
 		return null;


### PR DESCRIPTION
Try to fix proxy not found if autoDetect is enabled but detectAutoProxyConfigUrl returns empty string.