### PR TITLE
feat: replace commons-configuration2 with jini-lib for Firefox profil…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# proxy-vole - AI Agent Guidelines
+
+Guidelines for AI agents working on this codebase.
+
+## Project Info
+
+Proxy Vole is a Java library to auto detect the platform network proxy settings.
+
+- Java: 17+
+- Build: Maven 3.9.12+
+
+## AI Agent Rules of Engagement
+
+These rules apply to ALL AI agents working on this codebase.
+
+### Attribution
+
+- All AI-generated content (GitHub PR descriptions, review comments, JIRA comments) MUST clearly
+  identify itself as AI-generated and mention the human operator.
+  Example: "_Claude Code on behalf of [Human Name]_"
+- **Never guess or hallucinate the operator's name.** Always determine it programmatically:
+  - Use `gh api /user --jq '.login'` to get the authenticated GitHub username.
+  - If for any reason the lookup fails, omit the name rather than guessing.
+- AI coding agents MUST be configured to add co-authorship trailers to commits
+  (e.g., `Co-authored-by`). For Claude Code, enable this via the
+  [attribution settings](https://code.claude.com/docs/en/settings#attribution-settings).
+
+### Testing
+
+- Use JUnit Jupiter assertions (`assertEquals`, `assertTrue`, `assertFalse`, `assertNotNull`, etc.).

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,7 @@
 	<enforcer-no-snapshots.skip>false</enforcer-no-snapshots.skip>
     <maven.compiler.release>${java.version}</maven.compiler.release>
 	
-	<commons-configuration2.version>2.15.1</commons-configuration2.version>
-	<commons-lang3.version>3.20.0</commons-lang3.version>
+	<jini.version>0.6.14</jini.version>
 	<jna.version>5.19.1</jna.version>
 	<junit-jupiter.version>6.1.3</junit-jupiter.version>
 	<assertj.version>3.27.7</assertj.version>
@@ -74,8 +73,8 @@
       <artifactId>jna-platform</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-configuration2</artifactId>
+      <groupId>com.sshtools</groupId>
+      <artifactId>jini-lib</artifactId>
     </dependency>
     <dependency>
       <groupId>org.javadelight</groupId>
@@ -127,15 +126,10 @@
         <version>${jna.version}</version>
       </dependency>
 	  <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-configuration2</artifactId>
-        <version>${commons-configuration2.version}</version>
+        <groupId>com.sshtools</groupId>
+        <artifactId>jini-lib</artifactId>
+        <version>${jini.version}</version>
 	  </dependency>
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>${commons-lang3.version}</version>
-      </dependency>
       <dependency>
         <groupId>org.javadelight</groupId>
         <artifactId>delight-rhino-sandbox</artifactId>

--- a/src/main/java/com/github/markusbernhardt/proxy/search/browser/firefox/FirefoxProxySearchStrategy.java
+++ b/src/main/java/com/github/markusbernhardt/proxy/search/browser/firefox/FirefoxProxySearchStrategy.java
@@ -18,7 +18,6 @@ import com.github.markusbernhardt.proxy.util.PlatformUtil;
 import com.github.markusbernhardt.proxy.util.PlatformUtil.Platform;
 import com.github.markusbernhardt.proxy.util.ProxyException;
 import com.github.markusbernhardt.proxy.util.ProxyUtil;
-import org.apache.commons.configuration2.ex.ConfigurationException;
 
 /*****************************************************************************
  * Loads the Firefox3 proxy settings from the users Firefox3 settings. This will
@@ -171,7 +170,7 @@ public class FirefoxProxySearchStrategy implements ProxySearchStrategy {
 		try {
 			Properties settings = settingsParser.parseSettings(profileScanner);
 			return settings;
-		} catch (IOException | ConfigurationException e) {
+		} catch (IOException e) {
 			throw new ProxyException("No Firefox installation found");
 		}
 	}

--- a/src/main/java/com/github/markusbernhardt/proxy/search/browser/firefox/FirefoxSettingParser.java
+++ b/src/main/java/com/github/markusbernhardt/proxy/search/browser/firefox/FirefoxSettingParser.java
@@ -7,12 +7,14 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
-import org.apache.commons.configuration2.INIConfiguration;
-import org.apache.commons.configuration2.SubnodeConfiguration;
-import org.apache.commons.configuration2.ex.ConfigurationException;
+import com.sshtools.jini.INI;
+import com.sshtools.jini.INI.Section;
+import com.sshtools.jini.INIReader;
+import com.sshtools.jini.INIParseException;
 
 import com.github.markusbernhardt.proxy.util.Logger;
 import com.github.markusbernhardt.proxy.util.Logger.LogLevel;
@@ -44,7 +46,7 @@ class FirefoxSettingParser {
      *             on read error.
      ************************************************************************/
 
-    public Properties parseSettings(FirefoxProfileSource source) throws IOException, ConfigurationException {
+    public Properties parseSettings(FirefoxProfileSource source) throws IOException {
         File settingsFile = getSettingsFile(source);
 
         Properties result = new Properties();
@@ -95,31 +97,30 @@ class FirefoxSettingParser {
      * @throws IOException
      *             on read error.
      */
-    protected File getSettingsFile(FirefoxProfileSource source) throws IOException, ConfigurationException {
+    protected File getSettingsFile(FirefoxProfileSource source) throws IOException {
         // Read profiles.ini
         File profilesIniFile = source.getProfilesIni();
         if (profilesIniFile.exists()) {
-            final INIConfiguration profilesIni = new INIConfiguration();
-            
+
             try (FileReader fileReader = new FileReader(profilesIniFile)) {
-                profilesIni.read(fileReader);
+                final INI profilesIni = new INIReader.Builder().build().read(fileReader);
 
                 final List<String> keysFF67 =
-                    profilesIni.getSections().stream().filter(s -> s.startsWith("Install")).collect(Collectors.toList());
+                    profilesIni.sections().keySet().stream().filter(s -> s.startsWith("Install")).collect(Collectors.toList());
                 if (!keysFF67.isEmpty()) {
                     Logger.log(getClass(), LogLevel.DEBUG, "Firefox settings for FF67+ detected.");
 
                     for (String keyFF67 : keysFF67) {
 
                         Logger.log(getClass(), LogLevel.DEBUG, "Current FF67+ section key is: {}", keysFF67);
-                        SubnodeConfiguration section = profilesIni.getSection(keyFF67);
+                        Section section = profilesIni.section(keyFF67);
 
-                        Object propLocked = section.getProperty("Locked");
-                        if (propLocked != null && "1".equals(propLocked.toString())) {
-                            Object propDefault = section.getProperty("Default");
+                        String propLocked = section.getOr("Locked").orElse(null);
+                        if (propLocked != null && "1".equals(propLocked)) {
+                            String propDefault = section.getOr("Default").orElse(null);
                             if (propDefault != null) {
                               File profileFolder =
-                                  new File(profilesIniFile.getParentFile().getAbsolutePath(), propDefault.toString());
+                                  new File(profilesIniFile.getParentFile().getAbsolutePath(), propDefault);
                               Logger.log(getClass(), LogLevel.DEBUG, "Firefox settings folder is {}", profileFolder);
 
                               File settingsFile = new File(profileFolder, "prefs.js");
@@ -129,33 +130,34 @@ class FirefoxSettingParser {
                     }
                 }
                 else {  // no sections starting "Install" found, older version than FF67+ detected
-                    for (String section : profilesIni.getSections()) {
-                        SubnodeConfiguration confSection = profilesIni.getSection(section);
-                        
-                        if (confSection != null) {
-                            Logger
-                                .log(getClass(), LogLevel.TRACE, "Current entry, key: {}, value: {}", section,
-                                    confSection.toString());
+                    for (Map.Entry<String, Section[]> entry : profilesIni.sections().entrySet()) {
+                        String section = entry.getKey();
+                        Section confSection = entry.getValue()[0];
 
-                            Object propName = confSection.getProperty("Name");
-                            Object propRelative = confSection.getProperty("IsRelative");
-                            if (propName != null && propRelative != null) {
-                                if ("default".equals(propName.toString())
-                                    && "1".equals(propRelative.toString())) {
-                                    Object propPath = confSection.getProperty("Path");
-                                    if (propPath != null) {
-                                        File profileFolder =
-                                            new File(profilesIniFile.getParentFile().getAbsolutePath(), propPath.toString());
-                                        Logger.log(getClass(), LogLevel.DEBUG, "Firefox settings folder is {}", profileFolder);
+                        Logger
+                            .log(getClass(), LogLevel.TRACE, "Current entry, key: {}, value: {}", section,
+                                confSection.asString());
 
-                                        File settingsFile = new File(profileFolder, "prefs.js");
-                                        return settingsFile;
-                                    }
+                        String propName = confSection.getOr("Name").orElse(null);
+                        String propRelative = confSection.getOr("IsRelative").orElse(null);
+                        if (propName != null && propRelative != null) {
+                            if ("default".equals(propName)
+                                && "1".equals(propRelative)) {
+                                String propPath = confSection.getOr("Path").orElse(null);
+                                if (propPath != null) {
+                                    File profileFolder =
+                                        new File(profilesIniFile.getParentFile().getAbsolutePath(), propPath);
+                                    Logger.log(getClass(), LogLevel.DEBUG, "Firefox settings folder is {}", profileFolder);
+
+                                    File settingsFile = new File(profileFolder, "prefs.js");
+                                    return settingsFile;
                                 }
                             }
                         }
                     }
                 }
+            } catch (INIParseException e) {
+                throw new IOException("Error parsing the Firefox profiles.ini file", e);
             }
         }
         Logger.log(getClass(), LogLevel.DEBUG, "Firefox settings folder not found!");


### PR DESCRIPTION
…es.ini parsing

Use com.sshtools:jini-lib 0.6.14 instead of commons-configuration2. It is zero-dependency and Apache-2.0 licensed, and allows dropping the commons-lang3 transitive dependency. Migrate FirefoxSettingParser and FirefoxProxySearchStrategy off the commons-configuration2 API, wrapping INIParseException in IOException to preserve checked-IO semantics.

Also add AGENTS.md with AI agent guidelines.

fixes #273